### PR TITLE
Update cosign to latest release

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,9 +35,9 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+        uses: sigstore/cosign-installer@4959ce089c160fddf62f7166d3fc4bd8c1cd8356 # v3.9.2
         with:
-          cosign-release: 'v1.11.0'
+          cosign-release: 'v2.5.3'
 
 
       # Workaround: https://github.com/docker/build-push-action/issues/461

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,7 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@4959ce089c160fddf62f7166d3fc4bd8c1cd8356 # v3.9.2
+        uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
         with:
           cosign-release: 'v2.5.3'
 


### PR DESCRIPTION
Upgrade cosign-installer from v3.7.0 to v3.9.2 and cosign-release from v1.11.0 to v2.5.3.

🤖 Generated with [Claude Code](https://claude.ai/code)